### PR TITLE
Support configuring publish URL in sonatypeMavenCentral repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ to automatically deploy to a staging repository.
 publishing {
     repositories {
         sonatypeMavenCentral {
+            // If you need to publish to a different repository
+            url = "https://s01.oss.sonatype.org/service/local/"
+            // The default is https://oss.sonatype.org/service/local/
             credentials {
                 username 'XYZ'
                 password 'some-password'

--- a/README.md
+++ b/README.md
@@ -130,22 +130,36 @@ above, `sonatypeMavenCentral()` is also available, which transparently sets up
 the [nexus publish plugin](https://github.com/marcphilipp/nexus-publish-plugin)
 to automatically deploy to a staging repository.
 
+Note that you should use the `sonatypeSnapshots()` repository for publishing snapshots.
+
 <details>
 <summary>Example</summary>
 
 ```groovy
 publishing {
-    repositories {
-        sonatypeMavenCentral {
-            // If you need to publish to a different repository
-            url = "https://s01.oss.sonatype.org/service/local/"
-            // The default is https://oss.sonatype.org/service/local/
-            credentials {
-                username 'XYZ'
-                password 'some-password'
-            }
+  repositories {
+    // Switch which repository is used based on if the version is a snapshot
+    if("${project.version}".endsWith('-SNAPSHOT')) {
+      sonatypeSnapshots {
+        // The default is https://oss.sonatype.org/content/repositories/snapshots/
+        url = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+        credentials {
+          username 'XYZ'
+          password 'some-password'
         }
+      }
+    } else {
+      sonatypeMavenCentral {
+        // If you need to publish to a different repository
+        // The default is https://oss.sonatype.org/service/local/
+        url = "https://s01.oss.sonatype.org/service/local/"
+        credentials {
+          username 'XYZ'
+          password 'some-password'
+        }
+      }
     }
+  }
 }
 ```
 

--- a/src/integTest/java/eu/xenit/gradle/enterprise/conventions/integration/publish/OssIntegrationTest.java
+++ b/src/integTest/java/eu/xenit/gradle/enterprise/conventions/integration/publish/OssIntegrationTest.java
@@ -26,4 +26,14 @@ public class OssIntegrationTest extends AbstractIntegrationTest {
         createGradleRunner(integrationTests.resolve("publish/oss/mavenCentral")).build();
     }
 
+    @Test
+    public void mavenCentralNewUrl() throws IOException {
+        createGradleRunner(integrationTests.resolve("publish/oss/mavenCentralNewUrl")).build();
+    }
+
+    @Test
+    public void sonatypeSnapshots() throws IOException {
+        createGradleRunner(integrationTests.resolve("publish/oss/sonatypeSnapshots")).build();
+    }
+
 }

--- a/src/integTest/resources/eu/xenit/gradle/enterprise/conventions/integration/publish/oss/mavenCentralNewUrl/build.gradle
+++ b/src/integTest/resources/eu/xenit/gradle/enterprise/conventions/integration/publish/oss/mavenCentralNewUrl/build.gradle
@@ -6,6 +6,7 @@ plugins {
 publishing {
     repositories {
         sonatypeMavenCentral {
+            url = "https://s01.oss.sonatype.org/service/local/"
             credentials {
                 username "maven-central"
                 password "some-password"
@@ -16,5 +17,5 @@ publishing {
 
 afterEvaluate {
     assert publishing.repositories.stream().count() == 1
-    assert publishing.repositories.findByName("sonatype").url == uri("https://oss.sonatype.org/service/local/")
+    assert publishing.repositories.findByName("sonatype").url == uri("https://s01.oss.sonatype.org/service/local/")
 }

--- a/src/integTest/resources/eu/xenit/gradle/enterprise/conventions/integration/publish/oss/sonatypeSnapshots/build.gradle
+++ b/src/integTest/resources/eu/xenit/gradle/enterprise/conventions/integration/publish/oss/sonatypeSnapshots/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id "eu.xenit.enterprise-conventions.oss"
+    id "maven-publish"
+}
+
+publishing {
+    repositories {
+        sonatypeSnapshots {
+            credentials {
+                username "sonatype"
+                password "some-password"
+            }
+        }
+    }
+}
+
+afterEvaluate {
+    assert project.publishing.repositories.findByName("SonatypeSnapshots").url == uri("https://oss.sonatype.org/content/repositories/snapshots/")
+}

--- a/src/main/java/eu/xenit/gradle/enterprise/conventions/extensions/repository/RepositoryExtensionsPlugin.java
+++ b/src/main/java/eu/xenit/gradle/enterprise/conventions/extensions/repository/RepositoryExtensionsPlugin.java
@@ -25,7 +25,6 @@ public class RepositoryExtensionsPlugin implements
 
         project.getPlugins().withType(MavenPublishPlugin.class, publishPlugin -> {
             PublishingExtension publishing = project.getExtensions().getByType(PublishingExtension.class);
-            RepositoryHandlerExtensions.apply(publishing.getRepositories(), project);
             PublishRepositoryHandlerExtensions.apply(publishing.getRepositories(), project);
 
             // Replace publishing target for xenit private repository, because the download URL does not support upload

--- a/src/main/java/eu/xenit/gradle/enterprise/conventions/extensions/repository/SonatypeMavenCentralPublishRepository.java
+++ b/src/main/java/eu/xenit/gradle/enterprise/conventions/extensions/repository/SonatypeMavenCentralPublishRepository.java
@@ -1,7 +1,6 @@
 package eu.xenit.gradle.enterprise.conventions.extensions.repository;
 
 import de.marcphilipp.gradle.nexus.NexusRepository;
-import eu.xenit.gradle.enterprise.conventions.extensions.repository.MultiMavenArtifactRepository.LimitedMavenArtifactRepositoryException;
 import java.net.URI;
 import java.util.Set;
 import javax.inject.Inject;
@@ -42,17 +41,17 @@ public class SonatypeMavenCentralPublishRepository implements MavenArtifactRepos
 
     @Override
     public URI getUrl() {
-        throw new LimitedMavenArtifactRepositoryException();
+        return nexusRepository.getNexusUrl().get();
     }
 
     @Override
     public void setUrl(URI uri) {
-        throw new LimitedMavenArtifactRepositoryException();
+        nexusRepository.getNexusUrl().set(uri);
     }
 
     @Override
     public void setUrl(Object o) {
-        throw new LimitedMavenArtifactRepositoryException();
+        setUrl(URI.create(o.toString()));
     }
 
     @Override


### PR DESCRIPTION
Since sonatype added a second artifact repository for publishing, we need to support switching between the two repositories (and future additional ones) when creating a `sonatypeMavenCentral()` publishing repository.
